### PR TITLE
Update Program.cs

### DIFF
--- a/ContromeToOpenHAB/Program.cs
+++ b/ContromeToOpenHAB/Program.cs
@@ -66,8 +66,8 @@ namespace ContromeToOpenHAB
                                     itemsFile.WriteLine($"String Controme_Raw_{strEscapedName}_Soll {{http = \"<[{strCacheUrl}:10000:JSONPATH($..raeume[?(@.id=={strRoomID})].solltemperatur)]\"}}");
 
                                     itemsFile.WriteLine($"Group g{strEscapedName}Thermostat \"{strRoomName}\" (gFF) [ \"Thermostat\" ]");
-                                    itemsFile.WriteLine($"Number Controme_Proxy_{strEscapedName} \"{strRoomName} [% .2f °C]\"  (g{strEscapedName}Thermostat) [ \"CurrentTemperature\" ]");
-                                    itemsFile.WriteLine($"Number Controme_Proxy_{strEscapedName}_Soll \"{strRoomName} Soll[% .1f °C]\"  (g{strEscapedName}Thermostat) [ \"TargetTemperature\" ]");
+                                    itemsFile.WriteLine($"Number Controme_Proxy_{strEscapedName} \"{strRoomName} [% .2f] °C\"  (g{strEscapedName}Thermostat) [ \"CurrentTemperature\" ]");
+                                    itemsFile.WriteLine($"Number Controme_Proxy_{strEscapedName}_Soll \"{strRoomName} Soll[% .1f] °C\"  (g{strEscapedName}Thermostat) [ \"TargetTemperature\" ]");
                                     itemsFile.WriteLine();
 
 


### PR DESCRIPTION
The items definition in line 69 & 70 should be : [% .1f] °C & [% .2f] °C
The way the template defines items now ( [% .2f °C] & [% .1f °C ] ) is not supported by openhab2. The effect is , that none of the "proxy" items is created in openhab2.