### PR TITLE
results of "RuleReadJson" are wrong after update of OpenHAB

### DIFF
--- a/ContromeToOpenHAB/Program.cs
+++ b/ContromeToOpenHAB/Program.cs
@@ -211,16 +211,14 @@ import org.eclipse.xtext.xbase.lib.Functions
 val Functions.Function2 ContromeUnpackJsonArray = [
 NumberItem RuleProxyItem, StringItem RuleReadJson |
 	var jsonValue = RuleReadJson.state.toString;
-    var unpackedValue = jsonValue.substring(1, jsonValue.length() - 1);
-    postUpdate(RuleProxyItem, unpackedValue);
+        postUpdate(RuleProxyItem, jsonValue);
 ]");
             writer.WriteLine();
             writer.Write(@"
 val Functions.Function2 ContromeUnpackJsonArraySwitch = [
 SwitchItem RuleProxyItem, StringItem RuleReadJson |
 	var jsonValue = RuleReadJson.state.toString;
-    var unpackedValue = jsonValue.substring(1, jsonValue.length() - 1);
-    if(unpackedValue == ""1"")
+    if(jsonValue == ""1"")
     {
         RuleProxyItem.sendCommand(ON);
     }


### PR DESCRIPTION
proposed change of code - connected to https://github.com/BoBiene/ContromeToOpenHAB/issues/5

This change of code (can easily be applied in the Openhab rule file. ) solved my issue after Openhabian update. However it might be a problem with users, that run OpenHab versions before build #1204 - which is as well a snapshot version.
